### PR TITLE
lestrrat/go-lex breaks backwards compatibility

### DIFF
--- a/parser/builder.go
+++ b/parser/builder.go
@@ -80,7 +80,7 @@ func (b *Builder) Parse(name string, l lex.Lexer) (ast *AST, err error) {
 }
 
 func (b *Builder) Start(ctx *builderCtx) {
-	go ctx.Lexer.Run(ctx.Lexer)
+	go ctx.Lexer.Run()
 }
 
 func (b *Builder) Backup(ctx *builderCtx) {

--- a/parser/kolonish/lexer_test.go
+++ b/parser/kolonish/lexer_test.go
@@ -17,7 +17,7 @@ func makeLexer(input string) *parser.Lexer {
 
 func lexit(input string) *parser.Lexer {
 	l := makeLexer(input)
-	go l.Run(l)
+	go l.Run()
 	return l
 }
 

--- a/parser/tterse/lexer_test.go
+++ b/parser/tterse/lexer_test.go
@@ -21,7 +21,7 @@ func makeLexer(input string) *parser.Lexer {
 
 func lexit(input string) *parser.Lexer {
 	l := makeLexer(input)
-	go l.Run(l)
+	go l.Run()
 	return l
 }
 


### PR DESCRIPTION
I couldn't compile go-xslate, because the following commit in lestrrat/go-lex breaks backwards compatibility.
https://github.com/lestrrat/go-lex/commit/f5679f352de9e534a50592fb35abfa8422ba4acc

I fixed it.