### PR TITLE
go test on windows

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -59,7 +58,7 @@ func (f *File) FullPath() string {
 
 func (f *File) Mkdir() {
 	fullpath := f.FullPath()
-	dir := path.Dir(fullpath)
+	dir := filepath.Dir(fullpath)
 
 	_, err := os.Stat(dir)
 	if err != nil { // non-existent

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -329,15 +329,18 @@ func TestVM_FunCallFromDepot(t *testing.T) {
 }
 
 func TestVM_MethodCall(t *testing.T) {
+	t1 := time.Now()
+	t2 := t1.Add(time.Nanosecond)
+
 	bc := NewByteCode()
-	// tx.Render(..., &Vars { t: time.Now() })
-	// [% t.Before(time.Now()) %]
-	bc.AppendOp(TXOPLiteral, time.Now())
+	// tx.Render(..., &Vars { t: t1 })
+	// [% t.Before(t2) %]
+	bc.AppendOp(TXOPLiteral, t1)
 	bc.AppendOp(TXOPSaveToLvar, 0)
 	bc.AppendOp(TXOPPushmark)
 	bc.AppendOp(TXOPLoadLvar, 0)
 	bc.AppendOp(TXOPPush)
-	bc.AppendOp(TXOPLiteral, time.Now())
+	bc.AppendOp(TXOPLiteral, t2)
 	bc.AppendOp(TXOPPush)
 	bc.AppendOp(TXOPMethodCall, "Before")
 	bc.AppendOp(TXOPPopmark)


### PR DESCRIPTION
I ran `go test github.com/lestrrat/go-xslate/...` on Surface Book, but some tests were failed.

This patch will fix these tests for windows OS.